### PR TITLE
Load config defaults from in-jar resource

### DIFF
--- a/src/main/java/pro/cloudnode/smp/smpcore/BaseConfig.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/BaseConfig.java
@@ -10,7 +10,7 @@ import java.io.Reader;
 import java.util.Objects;
 
 public abstract class BaseConfig {
-    protected @NotNull YamlConfiguration config;
+    protected final @NotNull YamlConfiguration config;
     protected final @NotNull String path;
 
     protected BaseConfig(final @NotNull String path) {
@@ -19,7 +19,7 @@ public abstract class BaseConfig {
         load();
     }
 
-    protected final @NotNull YamlConfiguration load() {
+    protected final void load() {
         if (!file().exists()) saveDefault();
         try {
             this.config.load(file());
@@ -28,11 +28,10 @@ public abstract class BaseConfig {
         }
 
         this.config.addDefaults(YamlConfiguration.loadConfiguration(resource()));
-        return this.config;
     }
 
     public final void reload() {
-        config = load();
+        load();
     }
 
     private @NotNull File file() {

--- a/src/main/java/pro/cloudnode/smp/smpcore/BaseConfig.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/BaseConfig.java
@@ -3,7 +3,11 @@ package pro.cloudnode.smp.smpcore;
 import org.bukkit.configuration.file.YamlConfiguration;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.BufferedReader;
 import java.io.File;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Objects;
 
 public abstract class BaseConfig {
     protected @NotNull YamlConfiguration config;
@@ -11,12 +15,20 @@ public abstract class BaseConfig {
 
     protected BaseConfig(final @NotNull String path) {
         this.path = path;
-        this.config = load();
+        this.config = new YamlConfiguration();
+        load();
     }
 
     protected final @NotNull YamlConfiguration load() {
         if (!file().exists()) saveDefault();
-        return YamlConfiguration.loadConfiguration(file());
+        try {
+            this.config.load(file());
+        }
+        catch (final @NotNull Exception ignored) {
+        }
+
+        this.config.addDefaults(YamlConfiguration.loadConfiguration(resource()));
+        return this.config;
     }
 
     public final void reload() {
@@ -28,7 +40,10 @@ public abstract class BaseConfig {
     }
 
     public final void saveDefault() {
-        if (!file().exists())
-            SMPCore.getInstance().saveResource(path, false);
+        if (!file().exists()) SMPCore.getInstance().saveResource(path, false);
+    }
+
+    private @NotNull Reader resource() {
+        return new BufferedReader(new InputStreamReader(Objects.requireNonNull(SMPCore.getInstance().getResource(path))));
     }
 }


### PR DESCRIPTION
Continues to use [`YamlConfiguration`](https://jd.papermc.io/paper/1.20.4/org/bukkit/configuration/file/YamlConfiguration.html) which extends [`FileConfiguration`](https://jd.papermc.io/paper/1.20.4/org/bukkit/configuration/file/FileConfiguration.html), but now added [`MemoryConfiguration#addDefaults(Configuration)`](https://jd.papermc.io/paper/1.20.4/org/bukkit/configuration/MemoryConfiguration.html#addDefaults(org.bukkit.configuration.Configuration)) which supplies the default values from the in-jar resources.