### PR TITLE
Ensure players are in correct scoreboard team when they join

### DIFF
--- a/src/main/java/pro/cloudnode/smp/smpcore/Nation.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Nation.java
@@ -146,6 +146,10 @@ public final class Nation {
         }
     }
 
+    public static @NotNull Optional<@NotNull Nation> get(final @NotNull Team team) {
+        return get(team.getName());
+    }
+
     public static @NotNull Optional<@NotNull Nation> get(final @NotNull String id) {
         try (
                 final @NotNull Connection conn = SMPCore.getInstance().db()

--- a/src/main/java/pro/cloudnode/smp/smpcore/Nation.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Nation.java
@@ -96,7 +96,10 @@ public final class Nation {
         team.setCanSeeFriendlyInvisibles(true);
         team.displayName(Component.text(shortName).color(TextColor.color(Integer.decode("0x" + color))).hoverEvent(HoverEvent.showText(Component.text(name))));
         team.prefix(Component.text(shortName + " ").color(TextColor.color(Integer.decode("0x" + color))).hoverEvent(HoverEvent.showText(Component.text(name))));
-        for (final @NotNull Member member : members()) team.addPlayer(member.player());
+        for (final @NotNull Member member : members()) try {
+            team.addPlayer(member.player());
+        }
+        catch (final @NotNull IllegalArgumentException ignored) {}
         return team;
     }
 

--- a/src/main/java/pro/cloudnode/smp/smpcore/SMPCore.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/SMPCore.java
@@ -8,6 +8,7 @@ import org.jetbrains.annotations.Nullable;
 import pro.cloudnode.smp.smpcore.command.BanCommand;
 import pro.cloudnode.smp.smpcore.command.MainCommand;
 import pro.cloudnode.smp.smpcore.command.UnbanCommand;
+import pro.cloudnode.smp.smpcore.listener.NationTeamUpdaterListener;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,6 +53,8 @@ public final class SMPCore extends JavaPlugin {
 
         reload();
         initDatabase();
+
+        getServer().getPluginManager().registerEvents(new NationTeamUpdaterListener(), this);
 
         Objects.requireNonNull(getServer().getPluginCommand("smpcore")).setExecutor(new MainCommand());
         Objects.requireNonNull(getServer().getPluginCommand("ban")).setExecutor(new BanCommand());

--- a/src/main/java/pro/cloudnode/smp/smpcore/listener/NationTeamUpdaterListener.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/listener/NationTeamUpdaterListener.java
@@ -1,0 +1,46 @@
+package pro.cloudnode.smp.smpcore.listener;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.scoreboard.Team;
+import org.jetbrains.annotations.NotNull;
+import pro.cloudnode.smp.smpcore.Member;
+import pro.cloudnode.smp.smpcore.Nation;
+import pro.cloudnode.smp.smpcore.SMPCore;
+
+import java.util.Optional;
+
+/**
+ * When a player connects to the server, ensures that they are in the right Nation's team
+ */
+public final class NationTeamUpdaterListener implements Listener {
+    @EventHandler
+    public void onPlayerJoin(final @NotNull PlayerJoinEvent event) {
+        SMPCore.runAsync(() -> {
+            final @NotNull Player player = event.getPlayer();
+            final @NotNull Optional<@NotNull Member> member = Member.get(player);
+            final @NotNull Optional<@NotNull Team> team = Optional.ofNullable(player.getScoreboard()
+                    .getPlayerTeam(player));
+            final @NotNull Optional<@NotNull Nation> nationFromTeam = team.flatMap(Nation::get);
+            if (member.isEmpty()) {
+                // no longer a member, but in a nation's team?
+                nationFromTeam.ifPresent(ignored -> team.get().removePlayer(player));
+                return;
+            }
+            final @NotNull Optional<@NotNull Nation> nation = member.get().nation();
+            if (nation.isEmpty() && team.isPresent()) {
+                // no longer in a nation, but in a nation's team?
+                nationFromTeam.ifPresent(ignored -> team.get().removePlayer(player));
+                return;
+            }
+            if (nation.isPresent()) {
+                // in a nation and team, but not the nation's team?
+                if (team.isPresent() && !team.get().getName().equals(nation.get().getTeam().getName()))
+                    team.get().removePlayer(player);
+                nation.get().getTeam().addPlayer(player);
+            }
+        });
+    }
+}


### PR DESCRIPTION
- If the player is not a member but in a nation's team, they are removed from it.
- If the member is not in a nation, but in a nation's team, they are removed from it.
- If the member is in a nation, ensures they are in that nation's team.