### PR TITLE
Prevent revealing vanished players

### DIFF
--- a/src/main/java/pro/cloudnode/smp/smpcore/Member.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Member.java
@@ -2,6 +2,8 @@ package pro.cloudnode.smp.smpcore;
 
 import io.papermc.paper.ban.BanListType;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.entity.Player;
+import org.bukkit.metadata.MetadataValue;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -43,6 +45,17 @@ public final class Member {
 
     public @NotNull OfflinePlayer player() {
         return SMPCore.getInstance().getServer().getOfflinePlayer(uuid);
+    }
+
+    /**
+     * Check if player is online and not vanished
+     */
+    public boolean onlineNotVanished() {
+        final @NotNull Optional<@NotNull Player> player = Optional.ofNullable(player().getPlayer());
+        if (player.isEmpty()) return false;
+        for (final @NotNull MetadataValue meta : player.get().getMetadata("vanished"))
+            if (meta.asBoolean()) return false;
+        return player.get().isOnline();
     }
 
     public boolean isActive() {

--- a/src/main/java/pro/cloudnode/smp/smpcore/Messages.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Messages.java
@@ -239,6 +239,11 @@ public class Messages extends BaseConfig {
                         .ofNullable(player.getName()).orElse(player.getUniqueId().toString())));
     }
 
+    public @NotNull Component errorCommandOnStaff(final @NotNull String label) {
+        return MiniMessage.miniMessage()
+                .deserialize(Objects.requireNonNull(config.getString("error.command-on-staff")), Placeholder.unparsed("command", label));
+    }
+
     public record SubCommandArgument(@NotNull String name, boolean required) {
         public @NotNull Component component() {
             return required ? SMPCore.messages().subCommandArgumentRequired(name) : SMPCore.messages()

--- a/src/main/java/pro/cloudnode/smp/smpcore/Permission.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Permission.java
@@ -46,4 +46,9 @@ public final class Permission {
     public static @NotNull String ALT_REMOVE_JOINED = "smpcore.alt.remove.joined";
 
     public static @NotNull String SEEN = "smpcore.seen";
+
+    /**
+     * Allow using `/seen` on staff
+     */
+    public static @NotNull String SEEN_STAFF = "smpcore.seen.staff";
 }

--- a/src/main/java/pro/cloudnode/smp/smpcore/Rest.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Rest.java
@@ -39,7 +39,7 @@ public class Rest {
         obj.addProperty("banned", player.isBanned());
         obj.addProperty("altOwner", member.altOwnerUUID == null ? null : member.altOwnerUUID.toString());
         obj.addProperty("added", member.added.getTime());
-        obj.addProperty("lastSeen", player.getLastSeen());
+        obj.addProperty("lastSeen", member.staff ? 0 : player.getLastSeen());
         obj.addProperty("firstSeen", player.getFirstPlayed());
         obj.addProperty("active", member.isActive());
         return obj;
@@ -148,7 +148,7 @@ public class Rest {
                 altObj.addProperty("name", player.getName());
                 altObj.addProperty("nation", alt.nationID);
                 altObj.addProperty("added", alt.added.getTime());
-                altObj.addProperty("lastSeen", player.getLastSeen());
+                altObj.addProperty("lastSeen", alt.staff ? 0 : player.getLastSeen());
                 altsArray.add(altObj);
             }
             obj.add("alts", altsArray);

--- a/src/main/java/pro/cloudnode/smp/smpcore/Rest.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Rest.java
@@ -34,7 +34,7 @@ public class Rest {
         obj.addProperty("name", player.getName());
         obj.addProperty("nation", member.nationID);
         obj.addProperty("staff", member.staff);
-        obj.addProperty("online", player.isOnline());
+        obj.addProperty("online", member.onlineNotVanished());
         obj.addProperty("whitelisted", player.isWhitelisted());
         obj.addProperty("banned", player.isBanned());
         obj.addProperty("altOwner", member.altOwnerUUID == null ? null : member.altOwnerUUID.toString());
@@ -103,8 +103,8 @@ public class Rest {
             final @NotNull JsonArray arr = new JsonArray();
             for (final @NotNull Member member : members) {
                 if (filter != null) {
-                    if (filter.equals("online") && !member.player().isOnline()) continue;
-                    if (filter.equals("offline") && member.player().isOnline()) continue;
+                    if (filter.equals("online") && !member.onlineNotVanished()) continue;
+                    if (filter.equals("offline") && member.onlineNotVanished()) continue;
                     if (filter.equals("banned") && !member.player().isBanned()) continue;
                 }
                 final @NotNull JsonObject m = getMemberObject(member);

--- a/src/main/java/pro/cloudnode/smp/smpcore/command/SeenCommand.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/command/SeenCommand.java
@@ -23,6 +23,9 @@ public final class SeenCommand extends Command {
         if (!player.hasPlayedBefore()) return sendMessage(sender, SMPCore.messages().errorNeverJoined(player));
 
         final @NotNull Optional<@NotNull Member> member = Member.get(player.getUniqueId());
+
+        if (!sender.hasPermission(Permission.SEEN_STAFF) && member.isPresent() && member.get().staff) return sendMessage(sender, SMPCore.messages().errorCommandOnStaff(label));
+
         return member.map(m -> sendMessage(sender, SMPCore.messages().seen(m)))
                 .orElseGet(() -> sendMessage(sender, SMPCore.messages().seen(player)));
     }

--- a/src/main/java/pro/cloudnode/smp/smpcore/command/SeenCommand.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/command/SeenCommand.java
@@ -8,6 +8,7 @@ import pro.cloudnode.smp.smpcore.Permission;
 import pro.cloudnode.smp.smpcore.SMPCore;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 public final class SeenCommand extends Command {
@@ -32,6 +33,7 @@ public final class SeenCommand extends Command {
 
     @Override
     public @NotNull List<@NotNull String> tab(@NotNull CommandSender sender, @NotNull String label, @NotNull String @NotNull [] args) {
-        return Member.getNames().stream().toList();
+        if (sender.hasPermission(Permission.SEEN_STAFF)) return Member.getNames().stream().toList();
+        else return Member.get().stream().filter(m -> !m.staff).map(m -> m.player().getName()).filter(Objects::nonNull).toList();
     }
 }

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -52,3 +52,4 @@ error:
   member-not-alt: <red>(!) Member <gray><player></gray> is not an alt.</red>
   remove-joined-alt: <red>(!) You cannot remove alt player <gray><alt></gray> because they have played the server.</red>
   never-joined: <red>(!) Player <gray><player></gray> has never played on the server.</red>
+  command-on-staff: <red>(!) You cannot use <gray>/<command></gray> on staff.</red>


### PR DESCRIPTION
- [X] Members API `lastSeen` will now always return `0` (the same as "never joined") for staff members
- [X] Members API (including filter=online/offline) will now account for vanish for the `online` field
- [X] The `/seen` command requires an extra permission to be used on staff


> [!NOTE]
> Requires #18