### PR TITLE
Add a command and API endpoint to see the game date and time

### DIFF
--- a/src/main/java/pro/cloudnode/smp/smpcore/Messages.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Messages.java
@@ -11,11 +11,13 @@ import org.jetbrains.annotations.Nullable;
 
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.TimeZone;
 import java.util.stream.Collectors;
 
 public class Messages extends BaseConfig {
@@ -168,6 +170,16 @@ public class Messages extends BaseConfig {
                         .orElse(player.getUniqueId().toString())), Formatter.date("last-seen", lastSeen.toInstant()
                         .atZone(ZoneOffset.UTC)
                         .toLocalDateTime()), Placeholder.component("last-seen-relative", SMPCore.relativeTime(lastSeen)));
+    }
+
+    public @NotNull Component time(final @NotNull Date date) {
+        final @NotNull Calendar calendar = Calendar.getInstance(TimeZone.getTimeZone("UTC"));
+        calendar.setTime(date);
+        final int day = calendar.get(Calendar.DAY_OF_MONTH);
+        return MiniMessage.miniMessage()
+                .deserialize(Objects.requireNonNull(config.getString("time")), Formatter.date("date", calendar
+                        .toInstant().atZone(ZoneOffset.UTC)
+                        .toLocalDateTime()), Placeholder.unparsed("day", String.valueOf(day)), Placeholder.unparsed("day", String.valueOf(day)), Formatter.choice("day-format", day));
     }
 
     // errors

--- a/src/main/java/pro/cloudnode/smp/smpcore/Permission.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Permission.java
@@ -51,4 +51,9 @@ public final class Permission {
      * Allow using `/seen` on staff
      */
     public static @NotNull String SEEN_STAFF = "smpcore.seen.staff";
+
+    /**
+     * Allow seeing the game time and date
+     */
+    public static @NotNull String TIME = "smpcore.time";
 }

--- a/src/main/java/pro/cloudnode/smp/smpcore/Rest.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/Rest.java
@@ -69,6 +69,12 @@ public class Rest {
            ctx.header("Access-Control-Max-Age", "3600");
         });
 
+        javalin.get("/", ctx -> {
+            final @NotNull JsonObject obj = new JsonObject();
+            obj.addProperty("time", SMPCore.gameTime().getTime());
+            ctx.json(obj);
+        });
+
         javalin.get("/members", ctx -> {
             final @Nullable String filter = ctx.queryParam("filter");
             final @Nullable String limitString = ctx.queryParam("limit");

--- a/src/main/java/pro/cloudnode/smp/smpcore/SMPCore.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/SMPCore.java
@@ -3,6 +3,7 @@ package pro.cloudnode.smp.smpcore;
 import com.zaxxer.hikari.HikariConfig;
 import com.zaxxer.hikari.HikariDataSource;
 import net.kyori.adventure.text.Component;
+import org.bukkit.World;
 import org.bukkit.plugin.java.JavaPlugin;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -11,6 +12,7 @@ import pro.cloudnode.smp.smpcore.command.BanCommand;
 import pro.cloudnode.smp.smpcore.command.Command;
 import pro.cloudnode.smp.smpcore.command.MainCommand;
 import pro.cloudnode.smp.smpcore.command.SeenCommand;
+import pro.cloudnode.smp.smpcore.command.TimeCommand;
 import pro.cloudnode.smp.smpcore.command.UnbanCommand;
 import pro.cloudnode.smp.smpcore.listener.NationTeamUpdaterListener;
 
@@ -73,6 +75,7 @@ public final class SMPCore extends JavaPlugin {
             put("ban", new BanCommand());
             put("unban", new UnbanCommand());
             put("seen", new SeenCommand());
+            put("time", new TimeCommand());
         }};
         commands.put("alts", new AltsCommand(commands.get("smpcore")));
         for (final @NotNull Map.Entry<@NotNull String, @NotNull Command> entry : commands.entrySet())
@@ -191,5 +194,14 @@ public final class SMPCore extends JavaPlugin {
 
     public static @NotNull Component relativeTime(final @NotNull Date date) {
         return relativeTime(date, new Date());
+    }
+
+    private static @NotNull World overworld() {
+        return Objects.requireNonNull(getInstance().getServer().getWorlds().stream()
+                .filter(w -> w.getEnvironment() == World.Environment.NORMAL).findFirst().orElse(null));
+    }
+
+    public static @NotNull Date gameTime() {
+        return new Date(overworld().getGameTime() * 72);
     }
 }

--- a/src/main/java/pro/cloudnode/smp/smpcore/command/MainCommand.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/command/MainCommand.java
@@ -31,6 +31,7 @@ public final class MainCommand extends Command {
         return switch (args[0]) {
             case "reload" -> reload(sender);
             case "alt" -> alt(sender, argsSubset, label + " " + args[0]);
+            case "time", "date" -> time(sender, argsSubset, label + " " + args[0]);
             default -> sendMessage(sender, MiniMessage.miniMessage()
                     .deserialize("<red>(!) Unrecognised command <gray><command>", Placeholder.unparsed("command", args[0])));
         };
@@ -42,6 +43,7 @@ public final class MainCommand extends Command {
         if (args.length == 1) {
             if (sender.hasPermission(Permission.RELOAD)) suggestions.add("reload");
             if (sender.hasPermission(Permission.ALT)) suggestions.add("alt");
+            if (sender.hasPermission(Permission.TIME)) suggestions.addAll(List.of("time", "date"));
         }
         else if (args.length > 1) switch (args[0]) {
             case "alt" -> {
@@ -233,5 +235,11 @@ public final class MainCommand extends Command {
                 return sendMessage(sender, subCommandBuilder.build());
             }
         }
+    }
+
+    public static boolean time(final @NotNull CommandSender sender, final @NotNull String @NotNull [] args, final @NotNull String label) {
+        if (!sender.hasPermission(Permission.TIME))
+            return sendMessage(sender, SMPCore.messages().errorNoPermission());
+        return sendMessage(sender, SMPCore.messages().time(SMPCore.gameTime()));
     }
 }

--- a/src/main/java/pro/cloudnode/smp/smpcore/command/TimeCommand.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/command/TimeCommand.java
@@ -1,0 +1,19 @@
+package pro.cloudnode.smp.smpcore.command;
+
+import org.bukkit.command.CommandSender;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public final class TimeCommand extends Command {
+
+    @Override
+    public boolean run(@NotNull CommandSender sender, @NotNull String label, @NotNull String @NotNull [] args) {
+        return MainCommand.time(sender, args, label);
+    }
+
+    @Override
+    public @NotNull List<@NotNull String> tab(@NotNull CommandSender sender, @NotNull String label, @NotNull String @NotNull [] args) {
+        return List.of();
+    }
+}

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -39,6 +39,8 @@ seen:
   inactive: <aqua>(!) Member <white><player></white> is <red>inactive</red> and last seen on <white><last-seen:'dd MMM yyyy HH:mm'> UTC</white> <gray>(<last-seen-relative>)</aqua>
   non-member: <aqua>(!) Player <white><player></white> was last seen on <white><last-seen:'dd MMM yyyy HH:mm'> UTC</white> <gray>(<last-seen-relative>)</aqua>
 
+time: <green>(!) It is currently <white><date:'EEEE, MMMM'> <day><day-format:'1#st|2#nd|3#rd|3<th|21#st|22#nd|23#rd|23<th|31#st'> <date:'yyyy'></white> and the time is <white><date:'HH:mm'> UTC</white>.</green>
+
 error:
   no-permission: <red>(!) You don't have permission to use this command.</red>
   player-not-banned: <red>(!) Player <gray><player></gray> is not banned and is not a member.</red>

--- a/src/main/resources/messages.yml
+++ b/src/main/resources/messages.yml
@@ -39,7 +39,7 @@ seen:
   inactive: <aqua>(!) Member <white><player></white> is <red>inactive</red> and last seen on <white><last-seen:'dd MMM yyyy HH:mm'> UTC</white> <gray>(<last-seen-relative>)</aqua>
   non-member: <aqua>(!) Player <white><player></white> was last seen on <white><last-seen:'dd MMM yyyy HH:mm'> UTC</white> <gray>(<last-seen-relative>)</aqua>
 
-time: <green>(!) It is currently <white><date:'EEEE, MMMM'> <day><day-format:'1#st|2#nd|3#rd|3<th|21#st|22#nd|23#rd|23<th|31#st'> <date:'yyyy'></white> and the time is <white><date:'HH:mm'> UTC</white>.</green>
+time: <green>(!) Today is <white><date:'EEEE, MMMM'> <day><day-format:'1#st|2#nd|3#rd|3<th|21#st|22#nd|23#rd|23<th|31#st'> <date:'yyyy'></white> and the time is <white><date:'HH:mm'> UTC</white>.</green>
 
 error:
   no-permission: <red>(!) You don't have permission to use this command.</red>

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -27,3 +27,8 @@ commands:
     description: Check when a player was last online
     usage: /<command> <player>
     aliases: [ lastseen ]
+  time:
+    permission: smpcore.time
+    description: See the current game time and date
+    usage: /<command>
+    aliases: [ date, today ]


### PR DESCRIPTION
Command `/time`, `/date`, `/today`, `/smpcore time` will now show the current in-game date and time.

`GET /` will now return `{time: long}` with the current UNIX timestamp for the equivalent game time.