### PR TITLE
fix: allow member current nation to be empty for `/citizens add`

### DIFF
--- a/src/main/java/pro/cloudnode/smp/smpcore/command/NationCommand.java
+++ b/src/main/java/pro/cloudnode/smp/smpcore/command/NationCommand.java
@@ -615,8 +615,8 @@ public final class NationCommand extends Command {
         if (target.get().nationID != null && !sender.hasPermission(Permission.NATION_CITIZEN_ADD_SWITCH))
             return sendMessage(sender, SMPCore.messages().errorOtherCitizen(target.get()));
 
-        final var currentNation = target.get().nation().orElseThrow(() -> new IllegalStateException("Could not find nation " + target.get().nationID + " of member " + target.get().uuid));
-        if (currentNation.leaderUUID.equals(targetPlayer.getUniqueId()))
+        final var currentNation = target.get().nation();
+        if (currentNation.isPresent() && currentNation.get().leaderUUID.equals(targetPlayer.getUniqueId()))
             return sendMessage(sender, SMPCore.messages().errorKickLeadership());
 
         nation.add(target.get());


### PR DESCRIPTION
Introduced in #27 